### PR TITLE
command can be an empty string in RconType

### DIFF
--- a/Types/RconType.ts
+++ b/Types/RconType.ts
@@ -13,7 +13,7 @@ export class RconType extends SrcdsLogType.SrcdsLog {
 		this.Type = "Rcon";
 	 }
 	 static Identifier: Globals.RegexAssignment = {
-	 	regex: /^rcon from "(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d{1,5})": command "(.+)"$/
+	 	regex: /^rcon from "(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d{1,5})": command "(.*)"$/
 	 }
 
 }


### PR DESCRIPTION
Somehow it's possible to send empty RCON commands. I haven't been able to test this out myself, but a service we use called gameME frequently does it for whatever reason and the current RegEx does not pick it up.